### PR TITLE
fix crash Fatal Exception: java.lang.RuntimeException

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/bridge/EventEmitter.java
+++ b/android/app/src/main/java/com/reactnativenavigation/bridge/EventEmitter.java
@@ -57,41 +57,59 @@ public class EventEmitter {
         if (!NavigationApplication.instance.isReactContextInitialized()) {
             return;
         }
-        reactGateway.getReactEventEmitter().sendNavigatorEvent(eventId, navigatorEventId);
+        NavigationReactEventEmitter emitter = reactGateway.getReactEventEmitter();
+        if (emitter != null) {
+            emitter.sendNavigatorEvent(eventId, navigatorEventId);
+        }
     }
 
     public void sendNavigatorEvent(String eventId, String navigatorEventId, WritableMap data) {
         if (!NavigationApplication.instance.isReactContextInitialized()) {
             return;
         }
-        reactGateway.getReactEventEmitter().sendNavigatorEvent(eventId, navigatorEventId, data);
+        NavigationReactEventEmitter emitter = reactGateway.getReactEventEmitter();
+        if (emitter != null) {
+            emitter.sendNavigatorEvent(eventId, navigatorEventId, data);
+        }
     }
 
     public void sendEvent(String eventId, String navigatorEventId) {
         if (!NavigationApplication.instance.isReactContextInitialized()) {
             return;
         }
-        reactGateway.getReactEventEmitter().sendEvent(eventId, navigatorEventId);
+        NavigationReactEventEmitter emitter = reactGateway.getReactEventEmitter();
+        if (emitter != null) {
+            emitter.sendEvent(eventId, navigatorEventId);
+        }
     }
 
     public void sendNavigatorEvent(String eventId, WritableMap arguments) {
         if (!NavigationApplication.instance.isReactContextInitialized()) {
             return;
         }
-        reactGateway.getReactEventEmitter().sendEvent(eventId, arguments);
+        NavigationReactEventEmitter emitter = reactGateway.getReactEventEmitter();
+        if (emitter != null) {
+            emitter.sendEvent(eventId, arguments);
+        }
     }
 
     public void sendEvent(String eventId) {
         if (!NavigationApplication.instance.isReactContextInitialized()) {
             return;
         }
-        reactGateway.getReactEventEmitter().sendEvent(eventId, Arguments.createMap());
+        NavigationReactEventEmitter emitter = reactGateway.getReactEventEmitter();
+        if (emitter != null) {
+            emitter.sendEvent(eventId, Arguments.createMap());
+        }
     }
 
     public void sendAppLaunchedEvent() {
         if (!NavigationApplication.instance.isReactContextInitialized()) {
             return;
         }
-        reactGateway.getReactEventEmitter().sendEvent("RNN.appLaunched", Arguments.createMap());
+        NavigationReactEventEmitter emitter = reactGateway.getReactEventEmitter();
+        if (emitter != null) {
+            emitter.sendEvent("RNN.appLaunched", Arguments.createMap());
+        }
     }
 }


### PR DESCRIPTION
Fatal Exception: java.lang.RuntimeException
Unable to start activity ComponentInfo{com.riesapp/com.reactnativenavigation.controllers.NavigationActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'void com.reactnativenavigation.bridge.NavigationReactEventEmitter.sendNavigatorEvent(java.lang.String, java.lang.String, com.facebook.react.bridge.WritableMap)' on a null object reference

Решение:
https://github.com/wix/react-native-navigation/issues/3100